### PR TITLE
Add docs for ignore region / build name

### DIFF
--- a/wd-java-testng/README.md
+++ b/wd-java-testng/README.md
@@ -96,9 +96,9 @@
 
 - Run the test the way you are used to.
 
-## Advanced Usage
+## Advanced usage
 
-### Build Name
+### Build name
 
 `buildName` can be defined through the `SAUCE_VISUAL_BUILD_NAME` environment variable.
 
@@ -109,7 +109,7 @@ Example:
 export SAUCE_VISUAL_BUILD_NAME="Sauce Demo Test"
 ```
 
-### Ignored Regions
+### Ignored regions
 
 In the case you need to ignore some region when running your tests, Visual Testing provides a way to ignore user-specified areas.
 

--- a/wd-java-testng/README.md
+++ b/wd-java-testng/README.md
@@ -95,3 +95,43 @@
   ```
 
 - Run the test the way you are used to.
+
+## Advanced Usage
+
+### Build Name
+
+`buildName` can be defined through the `SAUCE_VISUAL_BUILD_NAME` environment variable.
+
+It needs to be defined prior to running your tests.
+
+Example:
+```sh
+export SAUCE_VISUAL_BUILD_NAME="Sauce Demo Test"
+```
+
+### Ignored Regions
+
+In the case you need to ignore some region when running your tests, Visual Testing provides a way to ignore user-specified areas.
+
+Those ignored regions are specified when requesting a new snapshot.
+
+A region is defined by four elements.
+- `x`, `y`: The location of the top-left corner of the ignored region
+- `width`: The width of the region to ignore
+- `height`: The heigh of the region to ignore
+
+*Note: all values are pixels*
+
+Example:
+```java
+  Options options = new Options();
+  IgnoreRegion ignoreRegion = new IgnoreRegion(
+    200, // width
+    200, // height
+    100, // x
+    100  // y
+  );
+  options.setIgnoreRegions(List.of(ignoreRegion));
+  visual.check("Before Login", options);
+```
+[Follow me](/wd-java-testng/src/test/java/com/example/InventoryIgnoreRegionsTest.java#L38-L41) to see complete working example

--- a/wd-java/README.md
+++ b/wd-java/README.md
@@ -95,3 +95,43 @@
   ```
 
 - Run the test the way you are used to.
+
+## Advanced Usage
+
+### Build Name
+
+`buildName` can be defined through the `SAUCE_VISUAL_BUILD_NAME` environment variable.
+
+It needs to be defined prior to running your tests.
+
+Example:
+```sh
+export SAUCE_VISUAL_BUILD_NAME="Sauce Demo Test"
+```
+
+### Ignored Regions
+
+In the case you need to ignore some region when running your tests, Visual Testing provides a way to ignore user-specified areas.
+
+Those ignored regions are specified when requesting a new snapshot.
+
+A region is defined by four elements.
+- `x`, `y`: The location of the top-left corner of the ignored region
+- `width`: The width of the region to ignore
+- `height`: The heigh of the region to ignore
+
+*Note: all values are pixels*
+
+Example:
+```java
+  Options options = new Options();
+  IgnoreRegion ignoreRegion = new IgnoreRegion(
+    200, // width
+    200, // height
+    100, // x
+    100  // y
+  );
+  options.setIgnoreRegions(List.of(ignoreRegion));
+  visual.check("Before Login", options);
+```
+[Follow me](/wd-java/src/test/java/com/example/InventoryIgnoreRegionsTest.java#L38-L41) to see complete working example

--- a/wd-java/README.md
+++ b/wd-java/README.md
@@ -96,9 +96,9 @@
 
 - Run the test the way you are used to.
 
-## Advanced Usage
+## Advanced usage
 
-### Build Name
+### Build name
 
 `buildName` can be defined through the `SAUCE_VISUAL_BUILD_NAME` environment variable.
 
@@ -109,7 +109,7 @@ Example:
 export SAUCE_VISUAL_BUILD_NAME="Sauce Demo Test"
 ```
 
-### Ignored Regions
+### Ignored regions
 
 In the case you need to ignore some region when running your tests, Visual Testing provides a way to ignore user-specified areas.
 

--- a/wdio/README.md
+++ b/wdio/README.md
@@ -101,3 +101,44 @@ export SAUCE_ACCESS_KEY=__YOUR_SAUCE_ACCESS_KEY__
 ```
 
 - Run the test the way you are used to.
+
+## Advanced Usage
+
+### Build Name
+
+`buildName` can be defined when adding `SauceVisualService` to you WebdriverIO project, through the `options` parameter.
+
+Example:
+``` ts
+    services: ['sauce', [SauceVisualService, {
+        buildName: 'Sauce Demo Test',
+    }]],
+```
+
+### Ignored Regions
+
+In the case you need to ignore some region when running your tests, Visual Testing provides a way to ignore user-specified areas.
+
+Those ignored regions are specified when requesting a new snapshot.
+
+A region is defined by four elements.
+- `x`, `y`: The location of the top-left corner of the ignored region
+- `width`: The width of the region to ignore
+- `height`: The heigh of the region to ignore
+
+*Note: all values are pixels*
+
+Example:
+```ts
+await browser.check('Before Login', {
+    ignore: [
+        {
+            x: 100,
+            y: 100,
+            width: 200,
+            height: 200,
+        },
+    ],
+});
+```
+[Follow me](/wdio/src/inventory-ignore-regions.spec.ts#L12) to see complete working example

--- a/wdio/README.md
+++ b/wdio/README.md
@@ -67,7 +67,7 @@ npm run sauce-visual-modified
 npm install --save @saucelabs/wdio-sauce-visual-service
 ```
 
-- Add the SauceVisualService to your `wdio.conf.(js|ts)`:
+- Add the SauceVisualService to your `wdio.conf.(js|ts)`:\
   *Build name can be set through the `buildName` attribute.*
 ```ts
 import { SauceVisualService } from '@saucelabs/wdio-sauce-visual-service'
@@ -102,9 +102,9 @@ export SAUCE_ACCESS_KEY=__YOUR_SAUCE_ACCESS_KEY__
 
 - Run the test the way you are used to.
 
-## Advanced Usage
+## Advanced usage
 
-### Build Name
+### Build name
 
 `buildName` can be defined when adding `SauceVisualService` to you WebdriverIO project, through the `options` parameter.
 
@@ -115,7 +115,7 @@ Example:
     }]],
 ```
 
-### Ignored Regions
+### Ignored regions
 
 In the case you need to ignore some region when running your tests, Visual Testing provides a way to ignore user-specified areas.
 


### PR DESCRIPTION
Increase affordance of settings (`buildName` / `ignoreRegion`) by mentioning them into the `README.md`s