### PR TITLE
adding windows command for setting user creds in Cypress readme and scripts

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -71,6 +71,13 @@ npm run cypress-ignored
 - Open the test or go to https://app.saucelabs.com/visual/builds to review changes.
 - Build should passed with "No changes" status.
 
+For Windows, replace the first 3 script lines in the package.json with:
+
+  "copy-standard": "copy \".\\cypress\\e2e\\saucedemo.standard.ts\" \".\\cypress\\e2e\\saucedemo.cy.ts\"",
+  "copy-locked": "copy \".\\cypress\\e2e\\saucedemo.locked.ts\" \".\\cypress\\e2e\\saucedemo.cy.ts\"",
+  "copy-ignored": "copy \".\\cypress\\e2e\\saucedemo.ignored.ts\" \".\\cypress\\e2e\\saucedemo.cy.ts\"",
+  
+
 ## Running with `saucectl`
 
 Alternatively, you can run your tests on Sauce Labs.

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -49,6 +49,7 @@ set SAUCE_USERNAME=__YOUR_SAUCE_USER_NAME__
 set SAUCE_ACCESS_KEY=__YOUR_SAUCE_ACCESS_KEY__
 
 - Run the test
+(for Windows, make sure to use the cmd window, NOT PowerShell)
 
 ```sh { name=npm-run }
 npm run cypress
@@ -76,7 +77,7 @@ For Windows, replace the first 3 script lines in the package.json with:
   "copy-standard": "copy \".\\cypress\\e2e\\saucedemo.standard.ts\" \".\\cypress\\e2e\\saucedemo.cy.ts\"",
   "copy-locked": "copy \".\\cypress\\e2e\\saucedemo.locked.ts\" \".\\cypress\\e2e\\saucedemo.cy.ts\"",
   "copy-ignored": "copy \".\\cypress\\e2e\\saucedemo.ignored.ts\" \".\\cypress\\e2e\\saucedemo.cy.ts\"",
-  
+
 
 ## Running with `saucectl`
 

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -36,13 +36,17 @@ cd visual-examples/cypress
 npm install
 ```
 
-- Configure with your Sauce credentials from https://app.saucelabs.com/user-settings and run
+- Configure with your Sauce credentials from https://app.saucelabs.com/user-settings and (in UNIX) run
 
 ```sh { name=set-credentials }
 export SAUCE_USERNAME=__YOUR_SAUCE_USER_NAME__
 export SAUCE_ACCESS_KEY=__YOUR_SAUCE_ACCESS_KEY__
 # to change the region you are testing in please change the `region` property in the cypress.config.ts file.
 ```
+
+In Windows, use the "set" command instead of the "export" command:
+set SAUCE_USERNAME=__YOUR_SAUCE_USER_NAME__
+set SAUCE_ACCESS_KEY=__YOUR_SAUCE_ACCESS_KEY__
 
 - Run the test
 


### PR DESCRIPTION
Please add these lines to make it easier for Windows users to consume your readme