### PR TITLE
IRIS-385 add mobile config

### DIFF
--- a/wdio/README.md
+++ b/wdio/README.md
@@ -51,7 +51,7 @@ desktop
 npm run sauce-visual
 ```
 
-or mobile
+or mobile (it might take couple minutes to finish all tests)
 
 ```sh
 npm run sauce-visual-mobile
@@ -67,7 +67,7 @@ desktop
 npm run sauce-visual-check
 ```
 
-or mobile
+or mobile (it might take couple minutes to finish all tests)
 
 ```sh
 npm run sauce-visual-check-mobile

--- a/wdio/README.md
+++ b/wdio/README.md
@@ -38,23 +38,39 @@ npm install
 - Configure with your Sauce credentials from https://app.saucelabs.com/user-settings and run
 
 ```sh { name=set-credentials }
-export SAUCE_USERNAME=__YOUR_SAUCE_USER_NAME__
-export SAUCE_ACCESS_KEY=__YOUR_SAUCE_ACCESS_KEY__
+export SAUCE_USERNAME=pawel.tomaszewski.iris
+export SAUCE_ACCESS_KEY=bf186ff5-3907-465b-9c4d-95b91c6ef5f6
 # to change the region you are testing in please change the `hostname property in the wdio.conf.ts file
 ```
 
 - Run the test
 
+desktop
+
 ```sh { name=npm-run }
 npm run sauce-visual
+```
+
+or mobile
+
+```sh
+npm run sauce-visual-mobile
 ```
 
 - Review your screenshots by clicking on the url printed in the test or go to https://app.saucelabs.com/visual/builds.
 - Accept all diffs, so they become new baselines.
 - Re-run the tests
 
+desktop
+
 ```sh { name=npm-run-modified }
 npm run sauce-visual-check
+```
+
+or mobile
+
+```sh
+npm run sauce-visual-check-mobile
 ```
 
 **NOTE:**

--- a/wdio/README.md
+++ b/wdio/README.md
@@ -38,8 +38,8 @@ npm install
 - Configure with your Sauce credentials from https://app.saucelabs.com/user-settings and run
 
 ```sh { name=set-credentials }
-export SAUCE_USERNAME=pawel.tomaszewski.iris
-export SAUCE_ACCESS_KEY=bf186ff5-3907-465b-9c4d-95b91c6ef5f6
+export SAUCE_USERNAME=__YOUR_SAUCE_USER_NAME__
+export SAUCE_ACCESS_KEY=__YOUR_SAUCE_ACCESS_KEY__
 # to change the region you are testing in please change the `hostname property in the wdio.conf.ts file
 ```
 

--- a/wdio/README.md
+++ b/wdio/README.md
@@ -51,7 +51,7 @@ desktop
 npm run sauce-visual
 ```
 
-or mobile (it might take couple minutes to finish all tests)
+or mobile
 
 ```sh
 npm run sauce-visual-mobile
@@ -67,7 +67,7 @@ desktop
 npm run sauce-visual-check
 ```
 
-or mobile (it might take couple minutes to finish all tests)
+or mobile
 
 ```sh
 npm run sauce-visual-check-mobile

--- a/wdio/package.json
+++ b/wdio/package.json
@@ -13,7 +13,9 @@
   },
   "scripts": {
     "sauce-visual": "wdio run ./src/configs/wdio.saucelabs.desktop.conf.ts --spec src/inventory.spec.ts",
-    "sauce-visual-check": "VISUAL_CHECK=true wdio run ./src/configs/wdio.saucelabs.desktop.conf.ts --spec src/inventory.spec.ts"
+    "sauce-visual-mobile": "wdio run ./src/configs/wdio.saucelabs.mobile.conf.ts --spec src/inventory.spec.ts",
+    "sauce-visual-check": "VISUAL_CHECK=true wdio run ./src/configs/wdio.saucelabs.desktop.conf.ts --spec src/inventory.spec.ts",
+    "sauce-visual-check-mobile": "VISUAL_CHECK=true wdio run ./src/configs/wdio.saucelabs.mobile.conf.ts --spec src/inventory.spec.ts"
   },
   "dependencies": {
     "@saucelabs/wdio-sauce-visual-service": "^0.3.84",

--- a/wdio/src/configs/wdio.saucelabs.desktop.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.desktop.conf.ts
@@ -47,4 +47,12 @@ export const config: Options.Testrunner = {
       },
     },
   ],
+  // =====
+  // Hooks
+  // =====
+  before: async (_capabilities, _specs) => {
+    // Set all browsers to the "same" viewport
+    // @ts-ignore
+    await browser.setWindowRect(1920, 1080);
+  },
 };

--- a/wdio/src/configs/wdio.saucelabs.desktop.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.desktop.conf.ts
@@ -52,7 +52,6 @@ export const config: Options.Testrunner = {
   // =====
   before: async (_capabilities, _specs) => {
     // Set all browsers to the "same" viewport
-    // @ts-ignore
-    await browser.setWindowRect(1920, 1080);
+    await browser.setWindowRect(null, null, 1920, 1080);
   },
 };

--- a/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
@@ -20,10 +20,14 @@ const iosCapabilities = ['15.5', '16.2'].map((iOSVersion) => ({
     ...(Math.floor(+iOSVersion) >= 16 ? { appiumVersion: '2.0.0' } : {}),
   },
 }));
-const iosRealCapabilities = ['15', '16'].map((iOSVersion) => ({
+const iosRealCapabilities = ['15'].map((iOSVersion) => ({
   ...iosCapabilitiesShared,
   'appium:platformVersion': iOSVersion,
-  'appium:deviceName': 'iPhone.*',
+  'appium:deviceName': 'iPhone X',
+  'sauce:options': {
+    appiumVersion: '2.0.0',
+    build,
+  },
 }));
 
 const androidCapabilitiesShared = {
@@ -41,11 +45,14 @@ const androidCapabilities = ['13.0', '14.0'].map(
     'appium:deviceName': 'Android GoogleAPI Emulator',
   })
 );
-const androidRealCapabilities = ['13', '14'].map(
+const androidRealCapabilities = ['13'].map(
   (androidVersion) => ({
     ...androidCapabilitiesShared,
     'appium:platformVersion': androidVersion,
-    'appium:deviceName': 'Google.*',
+    'appium:deviceName': 'Samsung Galaxy S22',
+    'sauce:options': {
+      build,
+    }
   })
 );
 
@@ -57,5 +64,7 @@ export const config: Options.Testrunner = {
   // For all capabilities please check
   // https://saucelabs.com/products/platform-configurator
   // and http://appium.io/docs/en/2.0/guides/caps/
-  capabilities: [...iosCapabilities, ...iosRealCapabilities, ...androidCapabilities, ...androidRealCapabilities],
+  // For available devices please check
+  // https://app.saucelabs.com/live/app-testing
+  capabilities: [ ...iosCapabilities, ...iosRealCapabilities, ...androidCapabilities, ...androidRealCapabilities],
 };

--- a/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
@@ -27,7 +27,10 @@ export const config: Options.Testrunner = {
     },
     {
       'appium:deviceName': 'iPhone 11',
-      'appium:platformVersion': '15',
+      // Platform Version is not mandatory for Real Devices
+      // If you want to use a specific or a range of versions then check
+      // https://docs.saucelabs.com/mobile-apps/supported-devices/#dynamic-device-allocation
+      // 'appium:platformVersion': '15',
       'appium:automationName': 'XCUITest',
       browserName: 'Safari',
       platformName: 'iOS',
@@ -47,7 +50,6 @@ export const config: Options.Testrunner = {
     },
     {
       'appium:deviceName': 'Google Pixel 8',
-      'appium:platformVersion': '14',
       'appium:automationName': 'UiAutomator2',
       browserName: 'Chrome',
       platformName: 'Android',

--- a/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
@@ -3,59 +3,6 @@ import { config as sauceSharedConfig } from './wdio.saucelabs.shared.conf.ts';
 
 const build = `Sauce Demo Test - ${new Date().getTime()}`;
 
-const iosCapabilitiesShared = {
-  'appium:automationName': 'XCUITest',
-  browserName: 'Safari',
-  platformName: 'iOS',
-  'sauce:options': {
-    build,
-  },
-}
-const iosCapabilities = ['15.5', '16.2'].map((iOSVersion) => ({
-  ...iosCapabilitiesShared,
-  'appium:platformVersion': iOSVersion,
-  'appium:deviceName': 'iPhone Simulator',
-  'sauce:options': {
-    build,
-    ...(Math.floor(+iOSVersion) >= 16 ? { appiumVersion: '2.0.0' } : {}),
-  },
-}));
-const iosRealCapabilities = ['15'].map((iOSVersion) => ({
-  ...iosCapabilitiesShared,
-  'appium:platformVersion': iOSVersion,
-  'appium:deviceName': 'iPhone X',
-  'sauce:options': {
-    appiumVersion: '2.0.0',
-    build,
-  },
-}));
-
-const androidCapabilitiesShared = {
-  'appium:automationName': 'UiAutomator2',
-  browserName: 'Chrome',
-  platformName: 'Android',
-  'sauce:options': {
-    build
-  },
-}
-const androidCapabilities = ['13.0', '14.0'].map(
-  (androidVersion) => ({
-    ...androidCapabilitiesShared,
-    'appium:platformVersion': androidVersion,
-    'appium:deviceName': 'Android GoogleAPI Emulator',
-  })
-);
-const androidRealCapabilities = ['13'].map(
-  (androidVersion) => ({
-    ...androidCapabilitiesShared,
-    'appium:platformVersion': androidVersion,
-    'appium:deviceName': 'Samsung Galaxy S22',
-    'sauce:options': {
-      build,
-    }
-  })
-);
-
 export const config: Options.Testrunner = {
   ...sauceSharedConfig,
   // ============
@@ -66,5 +13,48 @@ export const config: Options.Testrunner = {
   // and http://appium.io/docs/en/2.0/guides/caps/
   // For available devices please check
   // https://app.saucelabs.com/live/app-testing
-  capabilities: [ ...iosCapabilities, ...iosRealCapabilities, ...androidCapabilities, ...androidRealCapabilities],
+  capabilities: [
+    {
+      'appium:deviceName': 'iPhone Simulator',
+      'appium:platformVersion': '16.2',
+      'appium:automationName': 'XCUITest',
+      browserName: 'Safari',
+      platformName: 'iOS',
+      'sauce:options': {
+        appiumVersion: '2.0.0',
+        build
+      },
+    },
+    {
+      'appium:deviceName': 'iPhone 11',
+      'appium:platformVersion': '15',
+      'appium:automationName': 'XCUITest',
+      browserName: 'Safari',
+      platformName: 'iOS',
+      'sauce:options': {
+        build,
+      },
+    },
+    {
+      'appium:deviceName': 'Android GoogleAPI Emulator',
+      'appium:platformVersion': '14.0',
+      'appium:automationName': 'UiAutomator2',
+      browserName: 'Chrome',
+      platformName: 'Android',
+      'sauce:options': {
+        build
+      },
+    },
+    {
+      'appium:deviceName': 'Google Pixel 8',
+      'appium:platformVersion': '14',
+      'appium:automationName': 'UiAutomator2',
+      browserName: 'Chrome',
+      platformName: 'Android',
+      'sauce:options': {
+        appiumVersion: '2.0.0',
+        build
+      },
+    }
+  ],
 };

--- a/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
@@ -1,0 +1,61 @@
+import type { Options } from '@wdio/types';
+import { config as sauceSharedConfig } from './wdio.saucelabs.shared.conf.ts';
+
+const build = `Sauce Demo Test - ${new Date().getTime()}`;
+
+const iosCapabilitiesShared = {
+  'appium:automationName': 'XCUITest',
+  browserName: 'Safari',
+  platformName: 'iOS',
+  'sauce:options': {
+    build,
+  },
+}
+const iosCapabilities = ['15.5', '16.2'].map((iOSVersion) => ({
+  ...iosCapabilitiesShared,
+  'appium:platformVersion': iOSVersion,
+  'appium:deviceName': 'iPhone Simulator',
+  'sauce:options': {
+    build,
+    ...(Math.floor(+iOSVersion) >= 16 ? { appiumVersion: '2.0.0' } : {}),
+  },
+}));
+const iosRealCapabilities = ['15', '16'].map((iOSVersion) => ({
+  ...iosCapabilitiesShared,
+  'appium:platformVersion': iOSVersion,
+  'appium:deviceName': 'iPhone.*',
+}));
+
+const androidCapabilitiesShared = {
+  'appium:automationName': 'UiAutomator2',
+  browserName: 'Chrome',
+  platformName: 'Android',
+  'sauce:options': {
+    build
+  },
+}
+const androidCapabilities = ['13.0', '14.0'].map(
+  (androidVersion) => ({
+    ...androidCapabilitiesShared,
+    'appium:platformVersion': androidVersion,
+    'appium:deviceName': 'Android GoogleAPI Emulator',
+  })
+);
+const androidRealCapabilities = ['13', '14'].map(
+  (androidVersion) => ({
+    ...androidCapabilitiesShared,
+    'appium:platformVersion': androidVersion,
+    'appium:deviceName': 'Google.*',
+  })
+);
+
+export const config: Options.Testrunner = {
+  ...sauceSharedConfig,
+  // ============
+  // Capabilities
+  // ============
+  // For all capabilities please check
+  // https://saucelabs.com/products/platform-configurator
+  // and http://appium.io/docs/en/2.0/guides/caps/
+  capabilities: [...iosCapabilities, ...iosRealCapabilities, ...androidCapabilities, ...androidRealCapabilities],
+};

--- a/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
@@ -53,6 +53,12 @@ export const config: Options.Testrunner = {
     {
       'appium:deviceName': 'Google Pixel 8',
       'appium:automationName': 'UiAutomator2',
+      // Platform Version is not mandatory for Real Devices
+      // If you want to use a specific or a range of versions then check
+      // https://docs.saucelabs.com/mobile-apps/supported-devices/#dynamic-device-allocation
+      // If you don't specify a specific version it will select an available iPhone, as requested in `'appium:deviceName'`,
+      // with the then available OS version
+      // 'appium:platformVersion': '14',
       browserName: 'Chrome',
       platformName: 'Android',
       'sauce:options': {

--- a/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.mobile.conf.ts
@@ -30,6 +30,8 @@ export const config: Options.Testrunner = {
       // Platform Version is not mandatory for Real Devices
       // If you want to use a specific or a range of versions then check
       // https://docs.saucelabs.com/mobile-apps/supported-devices/#dynamic-device-allocation
+      // If you don't specify a specific version it will select an available iPhone, as requested in `'appium:deviceName'`,
+      // with the then available OS version 
       // 'appium:platformVersion': '15',
       'appium:automationName': 'XCUITest',
       browserName: 'Safari',

--- a/wdio/src/configs/wdio.saucelabs.shared.conf.ts
+++ b/wdio/src/configs/wdio.saucelabs.shared.conf.ts
@@ -23,6 +23,7 @@ export const config: Options.Testrunner = {
   // ============
   // Are not configured here, they can be found in:
   // - wdio.saucelabs.desktop.conf.ts
+  // - wdio.saucelabs.mobile.conf.ts
   //
   // ========
   // Services
@@ -48,12 +49,4 @@ export const config: Options.Testrunner = {
       },
     ],
   ]),
-  // =====
-  // Hooks
-  // =====
-  before: async (_capabilities, _specs) => {
-    // Set all browsers to the "same" viewport
-    // @ts-ignore
-    await browser.setWindowSize(1920, 1080);
-  },
 };


### PR DESCRIPTION
Issues:
- ignore os header and footer (time, and notifications can cause false negatives)
We can deal with it later
- missing browser version 
Showing just an icon is fine