### PR TITLE
Cypress node downgrade

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -2,7 +2,7 @@
   "name": "@saucelabs/cypress-visual-plugin-example",
   "description": "Sauce Labs Visual Example for Cypress",
   "engines": {
-    "node": "18"
+    "node": "^16.13 || >=18"
   },
   "scripts": {
     "copy-standard": "cp ./cypress/e2e/saucedemo.standard.ts ./cypress/e2e/saucedemo.cy.ts",


### PR DESCRIPTION
## Description
To give our customer an option to try to use our examples with node 16 support, we need to downgrade engines requirement in the cypress demo. This pull request extends node requirements and adds support for node 16 and 18 > 

## Types of Changes
- New feature (non-breaking change which adds functionality)

add support for node 16. 

## Deployment Notes
- 
