### PR TITLE
adding sauce visual types to tsconfig

### DIFF
--- a/wdio-cucumber/tsconfig.json
+++ b/wdio-cucumber/tsconfig.json
@@ -7,7 +7,8 @@
             "@wdio/globals/types",
             "expect-webdriverio",
             "@wdio/cucumber-framework",
-            "@wdio/sauce-service"
+            "@wdio/sauce-service",
+            "@saucelabs/wdio-sauce-visual-service",
         ],
         "allowSyntheticDefaultImports": true,
         "target": "es2022",

--- a/wdio-jasmine/tsconfig.json
+++ b/wdio-jasmine/tsconfig.json
@@ -7,7 +7,8 @@
             "@wdio/globals/types",
             "expect-webdriverio",
             "@wdio/jasmine-framework",
-            "@wdio/sauce-service"
+            "@wdio/sauce-service",
+            "@saucelabs/wdio-sauce-visual-service",
         ],
         "allowSyntheticDefaultImports": true,
         "target": "es2022",

--- a/wdio/tsconfig.json
+++ b/wdio/tsconfig.json
@@ -7,7 +7,8 @@
             "@wdio/globals/types",
             "expect-webdriverio",
             "@wdio/mocha-framework",
-            "@wdio/sauce-service"
+            "@wdio/sauce-service",
+            "@saucelabs/wdio-sauce-visual-service",
         ],
         "allowSyntheticDefaultImports": true,
         "target": "es2022",


### PR DESCRIPTION
# adding sauce visual types to tsconfig

vscode currently shows a compile error. adding our types to the tsconfig resolves that problem.