### PR TITLE
Java: Remove static version in README.md

### DIFF
--- a/wd-java-testng/README.md
+++ b/wd-java-testng/README.md
@@ -72,7 +72,7 @@ PLATFORM_NAME=ANDROID_EMULATOR ./mvnw clean test -Dtest=InventoryTest
   <scope>test</scope>
 </dependency>
 ```
-***Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)***
+*Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)*
 
 - Declare a RemoteWebDriver and a VisualApi instance as class variables
 

--- a/wd-java-testng/README.md
+++ b/wd-java-testng/README.md
@@ -68,10 +68,11 @@ PLATFORM_NAME=ANDROID_EMULATOR ./mvnw clean test -Dtest=InventoryTest
 <dependency>
   <groupId>com.saucelabs.visual</groupId>
   <artifactId>java-client</artifactId>
-  <version>0.3.134</version>
+  <version>LATEST VERSION</version>
   <scope>test</scope>
 </dependency>
 ```
+***Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)***
 
 - Declare a RemoteWebDriver and a VisualApi instance as class variables
 

--- a/wd-java-testng/README.md
+++ b/wd-java-testng/README.md
@@ -72,7 +72,7 @@ PLATFORM_NAME=ANDROID_EMULATOR ./mvnw clean test -Dtest=InventoryTest
   <scope>test</scope>
 </dependency>
 ```
-*Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)*
+*Latest available version can be found [here](https://central.sonatype.com/artifact/com.saucelabs.visual/java-client)*
 
 - Declare a RemoteWebDriver and a VisualApi instance as class variables
 

--- a/wd-java/README.md
+++ b/wd-java/README.md
@@ -72,7 +72,7 @@ PLATFORM_NAME=ANDROID_EMULATOR ./mvnw clean test -Dtest=InventoryTest
   <scope>test</scope>
 </dependency>
 ```
-***Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)***
+*Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)*
 
 - Declare a RemoteWebDriver and a VisualApi instance as class variables
 

--- a/wd-java/README.md
+++ b/wd-java/README.md
@@ -68,10 +68,11 @@ PLATFORM_NAME=ANDROID_EMULATOR ./mvnw clean test -Dtest=InventoryTest
 <dependency>
   <groupId>com.saucelabs.visual</groupId>
   <artifactId>java-client</artifactId>
-  <version>0.3.134</version>
+  <version>LATEST VERSION</version>
   <scope>test</scope>
 </dependency>
 ```
+***Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)***
 
 - Declare a RemoteWebDriver and a VisualApi instance as class variables
 

--- a/wd-java/README.md
+++ b/wd-java/README.md
@@ -72,7 +72,7 @@ PLATFORM_NAME=ANDROID_EMULATOR ./mvnw clean test -Dtest=InventoryTest
   <scope>test</scope>
 </dependency>
 ```
-*Latest available version can be found [here](https://search.maven.org/search?q=g:com.saucelabs.visual%20AND%20a:java-client)*
+*Latest available version can be found [here](https://central.sonatype.com/artifact/com.saucelabs.visual/java-client)*
 
 - Declare a RemoteWebDriver and a VisualApi instance as class variables
 


### PR DESCRIPTION
# One-line summary

> Issue : IRIS-871

## Description

- Removes the explicit (and outdated) version of `com.saucelabs.visual:java-client`.
- Adds a link to where to find the latest version (derived from [saucerest](https://github.com/saucelabs/saucerest-java?tab=readme-ov-file#maven))

Rendered version: https://github.com/saucelabs/visual-examples/tree/IRIS-871-remove-explicit-version/wd-java

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
