### PR TITLE
Use SAUCE_REGION for wdio and cypress

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -232,7 +232,7 @@ export default defineConfig({
   e2e: {
     [...]
     saucelabs: {
-      regionbuildName: 'eu-central-1',
+      region: 'eu-central-1',
     },
     [...]
   }

--- a/nightwatch/cucumberjs/README.md
+++ b/nightwatch/cucumberjs/README.md
@@ -67,13 +67,13 @@ npm run sauce-visual-check
 By default the tests will be executed on the US DC, if you want to run them on the EU DC then please run the following command
 
 ```sh { name=npm-run-eu }
-REGION=eu npm run sauce-visual
+SAUCE_REGION=eu-central-1 npm run sauce-visual
 ```
 
 or
 
 ```sh { name=npm-run-modified-eu }
-REGION=eu npm run sauce-visual-check
+SAUCE_REGION=eu-central-1 npm run sauce-visual-check
 ```
 
 - Open the test or go to https://app.saucelabs.com/visual/builds to review changes.

--- a/nightwatch/cucumberjs/nightwatch.conf.js
+++ b/nightwatch/cucumberjs/nightwatch.conf.js
@@ -44,10 +44,8 @@ module.exports = {
       silent: true,
       selenium: {
         host: `ondemand.${
-          process.env.REGION && process.env.REGION.toLocaleLowerCase() === 'eu'
-            ? 'eu-central'
-            : 'us-west'
-        }-1.saucelabs.com`,
+          process.env.SAUCE_REGION || 'us-west-1'
+        }.saucelabs.com`,
         port: 443,
       },
       desiredCapabilities: {

--- a/nightwatch/default/README.md
+++ b/nightwatch/default/README.md
@@ -67,13 +67,13 @@ npm run sauce-visual-check
 By default the tests will be executed on the US DC, if you want to run them on the EU DC then please run the following command
 
 ```sh { name=npm-run-eu }
-REGION=eu npm run sauce-visual
+SAUCE_REGION=eu-central-1 npm run sauce-visual
 ```
 
 or
 
 ```sh { name=npm-run-modified-eu }
-REGION=eu npm run sauce-visual-check
+SAUCE_REGION=eu-central-1 npm run sauce-visual-check
 ```
 
 - Open the test or go to https://app.saucelabs.com/visual/builds to review changes.

--- a/nightwatch/default/nightwatch.conf.js
+++ b/nightwatch/default/nightwatch.conf.js
@@ -44,10 +44,8 @@ module.exports = {
       silent: true,
       selenium: {
         host: `ondemand.${
-          process.env.REGION && process.env.REGION.toLocaleLowerCase() === 'eu'
-            ? 'eu-central'
-            : 'us-west'
-        }-1.saucelabs.com`,
+          process.env.SAUCE_REGION || 'us-west-1'
+        }.saucelabs.com`,
         port: 443,
       },
       desiredCapabilities: {

--- a/nightwatch/mocha/README.md
+++ b/nightwatch/mocha/README.md
@@ -67,13 +67,13 @@ npm run sauce-visual-check
 By default the tests will be executed on the US DC, if you want to run them on the EU DC then please run the following command
 
 ```sh { name=npm-run-eu }
-REGION=eu npm run sauce-visual
+SAUCE_REGION=eu-central-1 npm run sauce-visual
 ```
 
 or
 
 ```sh { name=npm-run-modified-eu }
-REGION=eu npm run sauce-visual-check
+SAUCE_REGION=eu-central-1 npm run sauce-visual-check
 ```
 
 - Open the test or go to https://app.saucelabs.com/visual/builds to review changes.

--- a/nightwatch/mocha/nightwatch.conf.js
+++ b/nightwatch/mocha/nightwatch.conf.js
@@ -43,10 +43,8 @@ module.exports = {
       silent: true,
       selenium: {
         host: `ondemand.${
-          process.env.REGION && process.env.REGION.toLocaleLowerCase() === 'eu'
-            ? 'eu-central'
-            : 'us-west'
-        }-1.saucelabs.com`,
+          process.env.SAUCE_REGION || 'us-west-1'
+        }.saucelabs.com`,
         port: 443,
       },
       desiredCapabilities: {

--- a/wdio-cucumber/README.md
+++ b/wdio-cucumber/README.md
@@ -79,13 +79,13 @@ npm run sauce-visual-check-mobile
 By default the tests will be executed on the US DC, if you want to run them on the EU DC then please run the following command
 
 ```sh { name=npm-run-eu }
-REGION=eu npm run sauce-visual
+SAUCE_REGION=eu-central-1 npm run sauce-visual
 ```
 
 or
 
 ```sh { name=npm-run-modified-eu }
-REGION=eu npm run sauce-visual-check
+SAUCE_REGION=eu-central- npm run sauce-visual-check
 ```
 
 - Open the test or go to https://app.saucelabs.com/visual/builds to review changes.

--- a/wdio-cucumber/tests/configs/wdio.saucelabs.shared.conf.ts
+++ b/wdio-cucumber/tests/configs/wdio.saucelabs.shared.conf.ts
@@ -14,7 +14,7 @@ export const config: Options.Testrunner = {
   // =================
   user: sauceUsername,
   key: sauceAccessKey,
-  region: (process.env.REGION || 'us') as Options.SauceRegions,
+  region: (process.env.SAUCE_REGION || 'us') as Options.SauceRegions,
   //
   // ============
   // Capabilities

--- a/wdio-jasmine/README.md
+++ b/wdio-jasmine/README.md
@@ -79,13 +79,13 @@ npm run sauce-visual-check-mobile
 By default the tests will be executed on the US DC, if you want to run them on the EU DC then please run the following command
 
 ```sh { name=npm-run-eu }
-REGION=eu npm run sauce-visual
+SAUCE_REGION=eu-central-1 npm run sauce-visual
 ```
 
 or
 
 ```sh { name=npm-run-modified-eu }
-REGION=eu npm run sauce-visual-check
+SAUCE_REGION=eu-central-1 npm run sauce-visual-check
 ```
 
 - Open the test or go to https://app.saucelabs.com/visual/builds to review changes.

--- a/wdio-jasmine/tests/configs/wdio.saucelabs.shared.conf.ts
+++ b/wdio-jasmine/tests/configs/wdio.saucelabs.shared.conf.ts
@@ -14,7 +14,7 @@ export const config: Options.Testrunner = {
   // =================
   user: sauceUsername,
   key: sauceAccessKey,
-  region: (process.env.REGION || 'us') as Options.SauceRegions,
+  region: (process.env.SAUCE_REGION || 'us') as Options.SauceRegions,
   //
   // ============
   // Capabilities

--- a/wdio/README.md
+++ b/wdio/README.md
@@ -79,13 +79,13 @@ npm run sauce-visual-check-mobile
 By default the tests will be executed on the US DC, if you want to run them on the EU DC then please run the following command
 
 ```sh { name=npm-run-eu }
-REGION=eu npm run sauce-visual
+SAUCE_REGION=eu-central-1 npm run sauce-visual
 ```
 
 or
 
 ```sh { name=npm-run-modified-eu }
-REGION=eu npm run sauce-visual-check
+SAUCE_REGION=eu-central-1 npm run sauce-visual-check
 ```
 
 - Open the test or go to https://app.saucelabs.com/visual/builds to review changes.

--- a/wdio/tests/configs/wdio.saucelabs.shared.conf.ts
+++ b/wdio/tests/configs/wdio.saucelabs.shared.conf.ts
@@ -15,7 +15,7 @@ export const config: Options.Testrunner = {
   // =================
   user: sauceUsername,
   key: sauceAccessKey,
-  region: (process.env.REGION || 'us') as Options.SauceRegions,
+  region: (process.env.SAUCE_REGION || 'us') as Options.SauceRegions,
   //
   // ============
   // Capabilities


### PR DESCRIPTION
> Issue : IRIS-1061

## Description
Use SAUCE_REGION instead of REGION for wdio and nightwatch examples

## Types of Changes
- Configuration change
- Refactor/improvements
- Documentation / non-code