### PR TITLE
fix order for native app tests

### DIFF
--- a/wdio-android-app/tests/specs/visual.spec.ts
+++ b/wdio-android-app/tests/specs/visual.spec.ts
@@ -41,6 +41,13 @@ describe('Android Native App', () => {
     });
   });
 
+  it('Captures only catalog content', async () => {
+    const catalogContent = await App.catalogContent;
+    await browser.sauceVisualCheck(`Catalog Fragment`, {
+      clipElement: catalogContent,
+    });
+  });
+
   // NOTE: Full page screenshot for native apps is in beta stage
   // some of the functionality may not work as expected (especially virtual devices, clipping, ignore regions)
   if (!!process.env.FPS) {
@@ -52,11 +59,4 @@ describe('Android Native App', () => {
       });
     });
   }
-
-  it('Captures only catalog content', async () => {
-    const catalogContent = await App.catalogContent;
-    await browser.sauceVisualCheck(`Catalog Fragment`, {
-      clipElement: catalogContent,
-    });
-  });
 });

--- a/wdio-ios-app/tests/specs/visual.spec.ts
+++ b/wdio-ios-app/tests/specs/visual.spec.ts
@@ -41,6 +41,13 @@ describe('iOS Native App', () => {
     });
   });
 
+  it('Captures only catalog content', async () => {
+    const catalogContent = await App.catalogContent;
+    await browser.sauceVisualCheck(`Catalog Fragment`, {
+      clipElement: catalogContent,
+    });
+  });
+
   // NOTE: Full page screenshot for native apps is in beta stage
   // some of the functionality may not work as expected (especially virtual devices, clipping, ignore regions)
   if (!!process.env.FPS) {
@@ -54,11 +61,4 @@ describe('iOS Native App', () => {
 
     }).timeout(4 * 60 * 1000); // scrolling on ios require more time
   }
-
-  it('Captures only catalog content', async () => {
-    const catalogContent = await App.catalogContent;
-    await browser.sauceVisualCheck(`Catalog Fragment`, {
-      clipElement: catalogContent,
-    });
-  });
 });


### PR DESCRIPTION
fps doesn't scroll at the end to the top of screen thats why temporary it needs to be in the end
